### PR TITLE
 Move Delegates Attachments Before Reader Connection

### DIFF
--- a/stripe_terminal/lib/src/stripe_terminal.dart
+++ b/stripe_terminal/lib/src/stripe_terminal.dart
@@ -144,19 +144,19 @@ class StripeTerminal {
     ReaderReconnectionDelegate? reconnectionDelegate,
   }) async {
     assert(!autoReconnectOnUnexpectedDisconnect || reconnectionDelegate == null);
+    _handlers.attachReaderDelegates(delegate, reconnectionDelegate);
     final connectedReader = await _platform.connectBluetoothReader(
       reader.serialNumber,
       locationId: locationId,
       autoReconnectOnUnexpectedDisconnect: autoReconnectOnUnexpectedDisconnect,
     );
-    _handlers.attachReaderDelegates(delegate, reconnectionDelegate);
     return connectedReader;
   }
 
   /// Attempts to connect to the given Handoff reader with a given connection configuration.
   Future<Reader> connectHandoffReader(Reader reader, {HandoffReaderDelegate? delegate}) async {
-    final connectedReader = await _platform.connectHandoffReader(reader.serialNumber);
     _handlers.attachReaderDelegates(delegate, null);
+    final connectedReader = await _platform.connectHandoffReader(reader.serialNumber);
     return connectedReader;
   }
 
@@ -184,11 +184,11 @@ class StripeTerminal {
     required String locationId,
     LocalMobileReaderDelegate? delegate,
   }) async {
+    _handlers.attachReaderDelegates(delegate, null);
     final connectedReader = await _platform.connectMobileReader(
       reader.serialNumber,
       locationId: locationId,
     );
-    _handlers.attachReaderDelegates(delegate, null);
     return connectedReader;
   }
 
@@ -201,12 +201,12 @@ class StripeTerminal {
     ReaderReconnectionDelegate? reconnectionDelegate,
   }) async {
     assert(!autoReconnectOnUnexpectedDisconnect || reconnectionDelegate == null);
+    _handlers.attachReaderDelegates(delegate, reconnectionDelegate);
     final connectedReader = await _platform.connectUsbReader(
       reader.serialNumber,
       locationId: locationId,
       autoReconnectOnUnexpectedDisconnect: autoReconnectOnUnexpectedDisconnect,
     );
-    _handlers.attachReaderDelegates(delegate, reconnectionDelegate);
     return connectedReader;
   }
 


### PR DESCRIPTION
In this commit, the sequence of operations in the `connectBluetoothReader` function has been modified to attach the `BluetoothReaderDelegate` and `ReaderReconnectionDelegate` before initiating the actual Bluetooth reader connection. 

Previously, the delegates were attached after the connection was established. This led to a significant issue: any events triggered during the connection process were not captured by the delegates. This is particularly problematic for events like mandatory firmware updates, which are automatically executed upon connection.

By moving the delegate attachment before the await connection call, we ensure that these delegates are active and ready to capture all relevant events that may occur during the connection process, including firmware updates, that may occur during the connection process. This change enhances the robustness of the event-handling mechanism and ensures that no critical events, like firmware updates, are missed.